### PR TITLE
Updates to emulator and navigation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,7 @@ namespace DOFConnect
     {
         string gCurrentGame = "";
         string gCurrentPlatform = "platforms";
+        string gCurrentEmulator = "";
 
         public void OnEventRaised(string eventType)
         {
@@ -21,14 +22,16 @@ namespace DOFConnect
                     // Do nothing
                     break;
                 case SystemEventTypes.LaunchBoxStartupCompleted:
-                    // TODO: Play cabinet's marquee, per the configuration
+                    // Play cabinet's marquee, per the configuration
+                    sendMenuNav("STARTUP");
                     break;
                 case SystemEventTypes.LaunchBoxShutdownBeginning:
                 case SystemEventTypes.BigBoxShutdownBeginning:
-                    // TODO: Go black
+                    sendMenuNav("BLANK");
                     break;
                 case SystemEventTypes.GameStarting:
                     // Play "launching" GIF
+                    sendMenuNav("LAUNCH");
                     break;
                 case SystemEventTypes.GameExited:
                     // Restore Game Marquee
@@ -49,33 +52,39 @@ namespace DOFConnect
             // Generate a DOFLinx message MENU_ROM="MAME,qbert"
             IPlatform selectedPlatform = PluginHelper.StateManager.GetSelectedPlatform();
             IGame[] selectedGames = PluginHelper.StateManager.GetAllSelectedGames();
-            if (selectedPlatform != null)
-            {
-                // If platform is not null, then we just selected a platform
-                // If we changed platform
-                if (gCurrentPlatform != selectedPlatform.Name)
-                {
-                    gCurrentPlatform = selectedPlatform.Name;
-                    if (selectedGames != null)
-                    {
-                        sendMenuRom(gCurrentPlatform, gCurrentGame);
-                    }
-                    else
-                    {
-                        // No game selected? Then display platform's marquee
-                        sendMenuRom("platforms", gCurrentPlatform);
-                    }
-                }
-            }
             if (selectedGames != null && selectedGames.Length > 0)
             {
                 IGame game = selectedGames[0];
-                if (gCurrentGame != game.ApplicationPath)
+                IEmulator emulator = PluginHelper.DataManager.GetEmulatorById(game.EmulatorId);
+                if (gCurrentGame != CleanGameName(game.ApplicationPath))
                 {
                     gCurrentGame = CleanGameName(game.ApplicationPath);
-                    sendMenuRom(gCurrentPlatform, gCurrentGame);
+                    gCurrentEmulator = emulator.Title;
+                    sendMenuRom(gCurrentEmulator, gCurrentGame);
                 }
             }
+            else
+            {
+                if (selectedPlatform != null)
+                {
+                    // If platform is not null, then we just selected a platform
+                    // If we changed platform
+                    if (gCurrentPlatform != selectedPlatform.Name)
+                    {
+                        gCurrentPlatform = selectedPlatform.Name;
+                        if (selectedGames != null)
+                        {
+                            sendMenuRom(gCurrentPlatform, gCurrentGame);
+                        }
+                        else
+                        {
+                            // No game selected? Then display platform's marquee
+                            sendMenuRom("platforms", gCurrentPlatform);
+                        }
+                    }
+                }
+            }
+
         }
         // Helper method to clean up the game name
         private string CleanGameName(string gamePath)
@@ -91,14 +100,26 @@ namespace DOFConnect
         public static void sendMenuRom(string platform, string game)
         {
             string romName = System.IO.Path.GetFileNameWithoutExtension(game);
+            sendMenuNav("MOVE");
+            sendMsg($"MENU_ROM={platform},{romName}");
+        }
 
+        // Method to send menu command to DOFLinx
+        public static void sendMenuNav(string cmd)
+        {
+            sendMsg($"MENU_NAVIGATION={cmd}");
+        }
+
+        // Send the required message to the DOFLinx pipe
+        public static void sendMsg(string msg)
+        {
             // Connect to DOFLinx named pipe
             using (var dofClient = new NamedPipeClientStream(".", "DOFLinx", PipeDirection.Out, PipeOptions.Asynchronous))
             {
                 dofClient.Connect(1000);
                 using (var dofSw = new StreamWriter(dofClient))
                 {
-                    dofSw.Write($"MENU_ROM={platform},{romName}");
+                    dofSw.Write(msg);
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # DOFConnect
 
 DOFConnect is a plugin for LaunchBox / BigBox that listens to system events, and send them to DOFLinx.
+
+Setup instructions can be found here (https://doflinx.github.io/docs/frontend-menu/05_LaunchBox.html)[https://doflinx.github.io/docs/frontend-menu/05_LaunchBox.html]
+


### PR DESCRIPTION
- Added a link to the setup instructions in readme.md
- Changed logic for the game category to go and get the emulator title
- Completed the "TO DO" list for Blanking, Launching and Startup using he DOFLinx MENU_NAVIGATION=
- Added a navigational "MOVE" to allow for navigation actions in DOFLinx

The BLANK, STARTUP, LAUNCH and MOVE definitions are in DOFLinx's MENU.INI which allows users to change the actions as they like.  I've done a section in the DOFLinx guide about this.

I will add a demonstrational video to the DOFLinx guide later today about LaunchBox.