### PR TITLE
Allow either platform of emulator to be used as the source category

### DIFF
--- a/DOFConnect.json
+++ b/DOFConnect.json
@@ -1,0 +1,3 @@
+{
+	"CategorySource": "Emulator"
+}


### PR DESCRIPTION
The last logic fix plus moving to use of the emulator as the category for the MENU_ROM=category,game has created difficulty for people using an emulator like Retroarch where many platforms use one emulator.  To address this, rather than lose any functionality of the emulator choice, I've made the source category selectable between the Emulator and Platform in a configuration file DOFConnect.json that resides in the DLL folder.  Now people can select the best configuration for them.

DOFConnect sends and information message to DOFLinx at startup showing the version (hard coded) of the DLL and the source category choice.